### PR TITLE
Fix memory leaks and improve cache management; bump 0.9.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,6 @@ dependencies {
 java {
     sourceCompatibility = JavaVersion.VERSION_25
     targetCompatibility = JavaVersion.VERSION_25
-    withSourcesJar()
 }
 
 tasks.withType(JavaCompile).configureEach {

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.jvmargs=-Xmx2G
 maven_group=com.mimicenzymes
 archives_base_name=litematica_container_filler
 
-mod_version=0.9.2-26.1
+mod_version=0.9.3-26.1
 minecraft_version=26.1
 loader_version=0.19.1
 fabric_version=0.145.1+26.1

--- a/src/main/java/com/mimicenzymes/litematicafiller/core/AreaScanner.java
+++ b/src/main/java/com/mimicenzymes/litematicafiller/core/AreaScanner.java
@@ -18,6 +18,8 @@ import java.util.Map;
 import java.util.Set;
 
 public class AreaScanner {
+    private static final long ATTEMPT_COOLDOWN_MS = 5000L;
+    private static final long ATTEMPT_RETENTION_MS = 60000L;
     private static final Map<BlockPos, Long> ATTEMPT_COOLDOWNS = new HashMap<>();
 
     private static class PendingTask {
@@ -45,6 +47,7 @@ public class AreaScanner {
         int r = Configs.FILL_RADIUS.getIntegerValue();
         boolean syncLayer = Configs.SYNC_LITE_LAYER.getBooleanValue();
         long now = System.currentTimeMillis();
+        ATTEMPT_COOLDOWNS.entrySet().removeIf(entry -> now - entry.getValue() > ATTEMPT_RETENTION_MS);
 
         int maxTasks = isSilentPrinter ? 15 : 40;
 
@@ -57,28 +60,7 @@ public class AreaScanner {
 
         if (r == 0) {
             for (BlockPos rawPos : com.mimicenzymes.litematicafiller.render.HighlightScanner.getHighlights().keySet()) {
-                BlockState state = schematicWorld.getBlockState(rawPos);
-                if (state == null || state.isAir() || !state.hasBlockEntity()) continue;
-
-                BlockPos[] halves = LitematicaContainerReader.getDoubleContainerHalves(schematicWorld, rawPos, state);
-                BlockPos taskPos = halves != null ? halves[0] : rawPos;
-
-                if (!processedPositions.add(taskPos)) continue;
-
-                if (eyePos.distanceToSqr(Vec3.atCenterOf(taskPos)) > reachSq) continue;
-
-                if (isSilentPrinter && ATTEMPT_COOLDOWNS.containsKey(taskPos) && now - ATTEMPT_COOLDOWNS.get(taskPos) < 5000) {
-                    continue;
-                }
-
-                Map<Integer, ItemStack> required = LitematicaContainerReader.getRequiredItems(taskPos, mc.level.registryAccess());
-                boolean isCrafter = state.getBlock() instanceof net.minecraft.world.level.block.CrafterBlock;
-                boolean needsLocking = isCrafter && LitematicaContainerReader.doesCrafterNeedLocking(taskPos, mc);
-                boolean hasItems = required != null && !required.isEmpty() && !RealContainerCache.isSatisfied(taskPos, required);
-
-                if (!hasItems && !needsLocking) continue;
-
-                pendingTasks.add(new PendingTask(taskPos, required == null ? new HashMap<>() : required, taskPos.distSqr(center)));
+                collectPendingTask(mc, schematicWorld, center, eyePos, reachSq, now, isSilentPrinter, processedPositions, pendingTasks, rawPos);
             }
         } else {
             for (int x = -r; x <= r; x++) {
@@ -88,29 +70,7 @@ public class AreaScanner {
 
                         if (syncLayer && !fi.dy.masa.litematica.data.DataManager.getRenderLayerRange().isPositionWithinRange(rawPos)) continue;
 
-                        BlockState state = schematicWorld.getBlockState(rawPos);
-                        if (state.isAir() || !state.hasBlockEntity()) continue;
-
-                        BlockPos[] halves = LitematicaContainerReader.getDoubleContainerHalves(schematicWorld, rawPos, state);
-                        BlockPos taskPos = halves != null ? halves[0] : rawPos;
-
-                        if (!processedPositions.add(taskPos)) continue;
-
-                        if (eyePos.distanceToSqr(Vec3.atCenterOf(taskPos)) > reachSq) continue;
-
-                        if (isSilentPrinter && ATTEMPT_COOLDOWNS.containsKey(taskPos) && now - ATTEMPT_COOLDOWNS.get(taskPos) < 5000) {
-                            continue;
-                        }
-
-                        Map<Integer, ItemStack> required = LitematicaContainerReader.getRequiredItems(taskPos, mc.level.registryAccess());
-
-                        boolean isCrafter = state.getBlock() instanceof net.minecraft.world.level.block.CrafterBlock;
-                        boolean needsLocking = isCrafter && LitematicaContainerReader.doesCrafterNeedLocking(taskPos, mc);
-                        boolean hasItems = required != null && !required.isEmpty() && !RealContainerCache.isSatisfied(taskPos, required);
-
-                        if (!hasItems && !needsLocking) continue;
-
-                        pendingTasks.add(new PendingTask(taskPos, required == null ? new HashMap<>() : required, taskPos.distSqr(center)));
+                        collectPendingTask(mc, schematicWorld, center, eyePos, reachSq, now, isSilentPrinter, processedPositions, pendingTasks, rawPos);
                     }
                 }
             }
@@ -123,6 +83,7 @@ public class AreaScanner {
             AutoFillerStateMachine.getInstance().addTask(task.pos, task.required);
             ATTEMPT_COOLDOWNS.put(task.pos, now);
             count++;
+
             if (count >= maxTasks) break;
         }
 
@@ -133,5 +94,39 @@ public class AreaScanner {
                 mc.gui.setOverlayMessage(Component.translatable("litematica_container_filler.message.no_requirements"), true);
             }
         }
+    }
+
+    private static void collectPendingTask(Minecraft mc,
+                                           net.minecraft.world.level.Level schematicWorld,
+                                           BlockPos center,
+                                           Vec3 eyePos,
+                                           double reachSq,
+                                           long now,
+                                           boolean isSilentPrinter,
+                                           Set<BlockPos> processedPositions,
+                                           List<PendingTask> pendingTasks,
+                                           BlockPos rawPos) {
+        BlockState state = schematicWorld.getBlockState(rawPos);
+        if (state == null || state.isAir() || !state.hasBlockEntity()) return;
+
+        BlockPos[] halves = LitematicaContainerReader.getDoubleContainerHalves(schematicWorld, rawPos, state);
+        BlockPos taskPos = halves != null ? halves[0] : rawPos;
+
+        if (!processedPositions.add(taskPos)) return;
+        if (eyePos.distanceToSqr(Vec3.atCenterOf(taskPos)) > reachSq) return;
+
+        Long lastAttempt = ATTEMPT_COOLDOWNS.get(taskPos);
+        if (isSilentPrinter && lastAttempt != null && now - lastAttempt < ATTEMPT_COOLDOWN_MS) {
+            return;
+        }
+
+        Map<Integer, ItemStack> required = LitematicaContainerReader.getRequiredItems(taskPos, mc.level.registryAccess());
+        boolean isCrafter = state.getBlock() instanceof net.minecraft.world.level.block.CrafterBlock;
+        boolean needsLocking = isCrafter && LitematicaContainerReader.doesCrafterNeedLocking(taskPos, mc);
+        boolean hasItems = required != null && !required.isEmpty() && !RealContainerCache.isSatisfied(taskPos, required);
+
+        if (!hasItems && !needsLocking) return;
+
+        pendingTasks.add(new PendingTask(taskPos, required == null ? new HashMap<>() : required, taskPos.distSqr(center)));
     }
 }

--- a/src/main/java/com/mimicenzymes/litematicafiller/core/LitematicaCache.java
+++ b/src/main/java/com/mimicenzymes/litematicafiller/core/LitematicaCache.java
@@ -8,17 +8,45 @@ import java.util.Map;
 
 public class LitematicaCache
 {
+    private static final long CACHE_TTL_MS = 300000L;
     private static final Map<BlockPos, Map<Integer, ItemStack>> CACHE = new HashMap<>();
+    private static final Map<BlockPos, Long> CACHE_TIME = new HashMap<>();
+
     public static void clear()
     {
         CACHE.clear();
+        CACHE_TIME.clear();
     }
+
     public static void put(BlockPos pos, Map<Integer, ItemStack> items)
     {
-        CACHE.put(pos, items);
+        BlockPos key = pos.immutable();
+        CACHE.put(key, items);
+        CACHE_TIME.put(key, System.currentTimeMillis());
     }
+
     public static Map<Integer, ItemStack> get(BlockPos pos)
     {
+        Long seenAt = CACHE_TIME.get(pos);
+        if (seenAt == null)
+        {
+            return CACHE.get(pos);
+        }
+
+        if (System.currentTimeMillis() - seenAt > CACHE_TTL_MS)
+        {
+            CACHE.remove(pos);
+            CACHE_TIME.remove(pos);
+            return null;
+        }
+
         return CACHE.get(pos);
+    }
+
+    public static void cleanupExpired()
+    {
+        long now = System.currentTimeMillis();
+        CACHE_TIME.entrySet().removeIf(entry -> now - entry.getValue() > CACHE_TTL_MS);
+        CACHE.keySet().removeIf(pos -> !CACHE_TIME.containsKey(pos));
     }
 }

--- a/src/main/java/com/mimicenzymes/litematicafiller/core/LitematicaChangeListener.java
+++ b/src/main/java/com/mimicenzymes/litematicafiller/core/LitematicaChangeListener.java
@@ -9,6 +9,8 @@ public class LitematicaChangeListener {
     public static void tick(Minecraft mc) {
         Object current = SchematicWorldHandler.getSchematicWorld();
 
+        LitematicaCache.cleanupExpired();
+
         if (current != lastSchematic) {
             lastSchematic = current;
             LitematicaContainerIndex.rebuildIndex(mc);

--- a/src/main/java/com/mimicenzymes/litematicafiller/core/LitematicaContainerIndex.java
+++ b/src/main/java/com/mimicenzymes/litematicafiller/core/LitematicaContainerIndex.java
@@ -8,10 +8,12 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Position;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class LitematicaContainerIndex {
     private static final List<BlockPos> CONTAINERS = new ArrayList<>();
+    private static final List<BlockPos> VIEW = Collections.unmodifiableList(CONTAINERS);
 
     public static void rebuildIndex(Minecraft mc) {
         CONTAINERS.clear();
@@ -51,5 +53,5 @@ public class LitematicaContainerIndex {
         SpatialContainerIndex.rebuild(CONTAINERS);
     }
 
-    public static List<BlockPos> getContainers() { return CONTAINERS; }
+    public static List<BlockPos> getContainers() { return VIEW; }
 }

--- a/src/main/java/com/mimicenzymes/litematicafiller/core/LitematicaContainerReader.java
+++ b/src/main/java/com/mimicenzymes/litematicafiller/core/LitematicaContainerReader.java
@@ -1,5 +1,6 @@
 package com.mimicenzymes.litematicafiller.core;
 
+import com.mojang.logging.LogUtils;
 import fi.dy.masa.litematica.world.SchematicWorldHandler;
 import net.minecraft.world.level.block.BarrelBlock;
 import net.minecraft.world.level.block.Blocks;
@@ -13,6 +14,7 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import org.slf4j.Logger;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -20,6 +22,7 @@ import java.util.Map;
 import java.util.Set;
 
 public class LitematicaContainerReader {
+    private static final Logger LOGGER = LogUtils.getLogger();
 
     public static BlockPos[] getDoubleContainerHalves(net.minecraft.world.level.Level world, BlockPos pos, BlockState state) {
         if (state.getBlock() instanceof ChestBlock) {
@@ -41,7 +44,7 @@ public class LitematicaContainerReader {
             BlockPos pos2 = pos.relative(bottomDir);
             BlockState state2 = world.getBlockState(pos2);
 
-            if (state2.is(net.minecraft.world.level.block.Blocks.BARREL) && state2.getValue(net.minecraft.world.level.block.BarrelBlock.FACING) == facing.getOpposite()) {
+            if (state2.is(Blocks.BARREL) && state2.getValue(BarrelBlock.FACING) == facing.getOpposite()) {
                 if (pos.compareTo(pos2) < 0) {
                     return new BlockPos[]{pos, pos2};
                 } else {
@@ -65,12 +68,14 @@ public class LitematicaContainerReader {
             Map<Integer, ItemStack> leftHalf = getSingleContainerItems(schematicWorld, halves[1], registries);
 
             items.putAll(rightHalf);
-            leftHalf.forEach((slot, stack) -> items.put(slot + 27, stack));
+
+            for (Map.Entry<Integer, ItemStack> entry : leftHalf.entrySet()) {
+                items.put(entry.getKey() + 27, entry.getValue());
+            }
         } else {
             items.putAll(getSingleContainerItems(schematicWorld, worldPos, registries));
         }
 
-        // 全局材料洗牌：确保读取出来的物品已经被你的规则替换过
         MaterialReplacer.replaceInMap(items);
 
         return items;
@@ -165,9 +170,12 @@ public class LitematicaContainerReader {
                     }
                 });
             } catch (Exception e) {
-                e.printStackTrace();
+                LOGGER.warn("Failed to read required item stack from schematic NBT", e);
             }
         }
+
+        MaterialReplacer.replaceInMap(items);
+
         return items;
     }
 }

--- a/src/main/java/com/mimicenzymes/litematicafiller/core/RealContainerCache.java
+++ b/src/main/java/com/mimicenzymes/litematicafiller/core/RealContainerCache.java
@@ -27,10 +27,13 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class RealContainerCache {
+    private static final long CACHE_TTL_MS = 300000L;
+    private static final int MAX_CACHE_ENTRIES = 2048;
     private static final Map<BlockPos, Map<Integer, ItemStack>> CACHE = new ConcurrentHashMap<>();
     private static final Map<BlockPos, Set<Integer>> LOCK_CACHE = new ConcurrentHashMap<>();
     private static final Map<BlockPos, Map<Integer, ItemStack>> SYNC_SNAPSHOT_CACHE = new ConcurrentHashMap<>();
     private static final Map<BlockPos, Long> SYNC_SNAPSHOT_TIME = new ConcurrentHashMap<>();
+    private static final Map<BlockPos, Long> CACHE_TIME = new ConcurrentHashMap<>();
     private static BlockPos lastLookedPos = null;
     private static final long SYNC_SNAPSHOT_TTL_MS = 15000L;
 
@@ -45,11 +48,30 @@ public class RealContainerCache {
         return cacheVersion;
     }
 
+    private static void cleanupExpiredCache() {
+        long now = System.currentTimeMillis();
+        CACHE_TIME.entrySet().removeIf(entry -> now - entry.getValue() > CACHE_TTL_MS);
+        CACHE.entrySet().removeIf(entry -> !CACHE_TIME.containsKey(entry.getKey()));
+        if (CACHE.size() > MAX_CACHE_ENTRIES) {
+            CACHE_TIME.entrySet().stream()
+                .sorted(Map.Entry.comparingByValue())
+                .limit(CACHE.size() - MAX_CACHE_ENTRIES)
+                .forEach(entry -> {
+                    CACHE.remove(entry.getKey());
+                    CACHE_TIME.remove(entry.getKey());
+                });
+        }
+    }
+
     public static void tick(Minecraft client) {
         if (client.level == null || client.player == null) return;
 
         if (client.level.getGameTime() % 100 == 0) {
             PENDING_NBT_REQUESTS.clear();
+        }
+
+        if (client.level.getGameTime() % 200 == 0) {
+            cleanupExpiredCache();
         }
 
         if (client.screen == null && client.hitResult instanceof BlockHitResult bhr) {
@@ -100,8 +122,11 @@ public class RealContainerCache {
         if (halves != null) {
             CACHE.put(halves[0].immutable(), items);
             CACHE.put(halves[1].immutable(), items);
+            CACHE_TIME.put(halves[0].immutable(), System.currentTimeMillis());
+            CACHE_TIME.put(halves[1].immutable(), System.currentTimeMillis());
         } else {
             CACHE.put(pos.immutable(), items);
+            CACHE_TIME.put(pos.immutable(), System.currentTimeMillis());
         }
 
         if (handler instanceof net.minecraft.world.inventory.CrafterMenu crafterHandler) {
@@ -116,6 +141,12 @@ public class RealContainerCache {
     }
 
     public static Map<Integer, ItemStack> getCachedItems(BlockPos pos) {
+        Long seenAt = CACHE_TIME.get(pos);
+        if (seenAt != null && System.currentTimeMillis() - seenAt > CACHE_TTL_MS) {
+            CACHE.remove(pos);
+            CACHE_TIME.remove(pos);
+            return null;
+        }
         if (CACHE.containsKey(pos)) return CACHE.get(pos);
 
         var schematicWorld = fi.dy.masa.litematica.world.SchematicWorldHandler.getSchematicWorld();

--- a/src/main/java/com/mimicenzymes/litematicafiller/core/SpatialContainerIndex.java
+++ b/src/main/java/com/mimicenzymes/litematicafiller/core/SpatialContainerIndex.java
@@ -2,10 +2,12 @@ package com.mimicenzymes.litematicafiller.core;
 
 import net.minecraft.core.BlockPos;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class SpatialContainerIndex {
     private static final List<BlockPos> POSITIONS = new ArrayList<>();
+    private static final List<BlockPos> VIEW = Collections.unmodifiableList(POSITIONS);
 
     public static void rebuild(List<BlockPos> containers) {
         POSITIONS.clear();
@@ -26,5 +28,9 @@ public class SpatialContainerIndex {
             }
         }
         return result;
+    }
+
+    public static List<BlockPos> getPositions() {
+        return VIEW;
     }
 }

--- a/src/main/java/com/mimicenzymes/litematicafiller/core/SpatialKDTree.java
+++ b/src/main/java/com/mimicenzymes/litematicafiller/core/SpatialKDTree.java
@@ -25,31 +25,31 @@ public class SpatialKDTree
 
     public void build(List<BlockPos> points)
     {
-        root = buildRecursive(points, 0);
+        root = buildRecursive(new ArrayList<>(points), 0, 0, points.size());
     }
 
-    private Node buildRecursive(List<BlockPos> points, int depth)
+    private Node buildRecursive(List<BlockPos> points, int depth, int start, int end)
     {
-        if (points.isEmpty())
+        if (start >= end)
         {
             return null;
         }
 
         int axis = depth % 3;
 
-        points.sort((a, b) ->
+        points.subList(start, end).sort((a, b) ->
         {
             if (axis == 0) return Integer.compare(a.getX(), b.getX());
             if (axis == 1) return Integer.compare(a.getY(), b.getY());
             return Integer.compare(a.getZ(), b.getZ());
         });
 
-        int mid = points.size() / 2;
+        int mid = start + (end - start) / 2;
 
         Node node = new Node(points.get(mid), axis);
 
-        node.left = buildRecursive(new ArrayList<>(points.subList(0, mid)), depth + 1);
-        node.right = buildRecursive(points.subList(mid + 1, points.size()), depth + 1);
+        node.left = buildRecursive(points, depth + 1, start, mid);
+        node.right = buildRecursive(points, depth + 1, mid + 1, end);
 
         return node;
     }

--- a/src/main/java/com/mimicenzymes/litematicafiller/network/ServuxSyncHandler.java
+++ b/src/main/java/com/mimicenzymes/litematicafiller/network/ServuxSyncHandler.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class ServuxSyncHandler {
+    private static final int MAX_INDEPENDENT_CACHE_SIZE = 1024;
 
     public static final Map<BlockPos, Map<Integer, ItemStack>> INDEPENDENT_CACHE = new ConcurrentHashMap<>();
 
@@ -27,7 +28,7 @@ public class ServuxSyncHandler {
             ClientPlayNetworking.registerGlobalReceiver(ServuxResponsePayload.ID, (payload, context) -> {
                 context.client().execute(() -> {
                     if (payload.pos() != null && payload.items() != null) {
-                        INDEPENDENT_CACHE.put(payload.pos().immutable(), payload.items());
+                        putIndependentCache(payload.pos().immutable(), payload.items());
                     }
                 });
             });
@@ -172,5 +173,16 @@ public class ServuxSyncHandler {
         }
 
         return false;
+    }
+
+    private static void putIndependentCache(BlockPos pos, Map<Integer, ItemStack> items) {
+        if (INDEPENDENT_CACHE.size() >= MAX_INDEPENDENT_CACHE_SIZE) {
+            var iterator = INDEPENDENT_CACHE.keySet().iterator();
+            if (iterator.hasNext()) {
+                iterator.next();
+                iterator.remove();
+            }
+        }
+        INDEPENDENT_CACHE.put(pos, items);
     }
 }

--- a/src/main/java/com/mimicenzymes/litematicafiller/render/HighlightRenderer.java
+++ b/src/main/java/com/mimicenzymes/litematicafiller/render/HighlightRenderer.java
@@ -1,5 +1,6 @@
 package com.mimicenzymes.litematicafiller.render;
 
+import com.mojang.logging.LogUtils;
 import com.mimicenzymes.litematicafiller.config.Configs;
 import fi.dy.masa.malilib.render.MaLiLibPipelines;
 import fi.dy.masa.malilib.render.RenderContext;
@@ -7,12 +8,15 @@ import fi.dy.masa.malilib.render.RenderUtils;
 import fi.dy.masa.malilib.util.data.Color4f;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
-import com.mojang.blaze3d.vertex.MeshData;
+import net.minecraft.client.renderer.RenderBuiltBuffer;
+import org.slf4j.Logger;
 
 import java.util.Map;
 
 public class HighlightRenderer {
     private static final HighlightRenderer INSTANCE = new HighlightRenderer();
+    private static final Logger LOGGER = LogUtils.getLogger();
+
     public static HighlightRenderer getInstance() { return INSTANCE; }
 
     public void render() {
@@ -22,12 +26,15 @@ public class HighlightRenderer {
         if (highlights.isEmpty()) return;
 
         Minecraft client = Minecraft.getInstance();
-        if (client.level == null || client.player == null) return;
+        if (client == null || client.level == null || client.player == null) return;
+
+        RenderContext ctx = null;
+        RenderBuiltBuffer meshData = null;
 
         try {
             boolean xray = Configs.HIGHLIGHT_XRAY.getBooleanValue();
 
-            RenderContext ctx = new RenderContext(
+            ctx = new RenderContext(
                     () -> "litematica_filler_lines",
                     xray ? MaLiLibPipelines.DEBUG_LINES_MASA_SIMPLE_NO_DEPTH_NO_CULL : MaLiLibPipelines.DEBUG_LINES_MASA_SIMPLE_OFFSET_2
             );
@@ -36,20 +43,24 @@ public class HighlightRenderer {
             if (buffer == null) return;
 
             float lineWidth = Math.max(2.5F, (float)client.getWindow().getWidth() / 1920.0F * 2.5F);
+
             for (Map.Entry<BlockPos, HighlightState> entry : highlights.entrySet()) {
                 Color4f c = getColor(entry.getValue());
                 RenderUtils.drawBlockBoundingBoxOutlinesBatchedLinesSimple(entry.getKey(), c, 0.015, lineWidth, buffer);
             }
-
-            MeshData meshData = buffer.build();
+            meshData = buffer.build();
             if (meshData != null) {
                 ctx.draw(meshData, false, true);
+            }
+        } catch (Exception e) {
+            LOGGER.warn("Failed to render container highlights", e);
+        } finally {
+            if (meshData != null) {
                 meshData.close();
             }
-
-            ctx.reset();
-
-        } catch (Throwable e) {
+            if (ctx != null) {
+                ctx.reset();
+            }
         }
     }
     private Color4f getColor(HighlightState type) {

--- a/src/main/java/com/mimicenzymes/litematicafiller/render/HighlightScanner.java
+++ b/src/main/java/com/mimicenzymes/litematicafiller/render/HighlightScanner.java
@@ -1,5 +1,9 @@
 package com.mimicenzymes.litematicafiller.render;
 
+import com.mimicenzymes.litematicafiller.config.Configs;
+import com.mimicenzymes.litematicafiller.core.ItemMatcher;
+import com.mimicenzymes.litematicafiller.core.LitematicaContainerReader;
+import com.mimicenzymes.litematicafiller.core.RealContainerCache;
 import net.minecraft.network.chat.Component;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.block.state.BlockState;
@@ -13,26 +17,20 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.nbt.NumericTag;
 
-
-import com.mimicenzymes.litematicafiller.config.Configs;
-import com.mimicenzymes.litematicafiller.core.ItemMatcher;
-import com.mimicenzymes.litematicafiller.core.LitematicaContainerReader;
-import com.mimicenzymes.litematicafiller.core.RealContainerCache;
-
-
-
-
-
-
-
-
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 public class HighlightScanner {
     private static final Map<BlockPos, HighlightState> HIGHLIGHT_MAP = new ConcurrentHashMap<>();
     private static final Map<BlockPos, Map<Integer, ItemStack>> SCHEMATIC_REQ_CACHE = new ConcurrentHashMap<>();
+    private static final ExecutorService INDEX_EXECUTOR = Executors.newSingleThreadExecutor(r -> {
+        Thread thread = new Thread(r, "LitematicaFiller-HighlightScanner");
+        thread.setDaemon(true);
+        return thread;
+    });
     private static volatile Set<BlockPos> SCHEMATIC_CONTAINERS = Collections.emptySet();
     private static long lastIndexTime = 0;
     private static boolean isIndexing = false;
@@ -82,7 +80,7 @@ public class HighlightScanner {
             return;
         }
 
-        if (tickCounter % 100 == 0) SCHEMATIC_REQ_CACHE.clear();
+        if (tickCounter % 200 == 0) SCHEMATIC_REQ_CACHE.clear();
 
         long now = System.currentTimeMillis();
         if (!isIndexing && (now - lastIndexTime > 5000 || SCHEMATIC_CONTAINERS.isEmpty())) {
@@ -95,7 +93,7 @@ public class HighlightScanner {
                     lastIndexTime = System.currentTimeMillis();
                     isIndexing = false;
                 }
-            });
+            }, INDEX_EXECUTOR);
         }
 
         boolean hideCompleted = Configs.HIDE_COMPLETED_CONTAINERS.getBooleanValue();
@@ -262,7 +260,7 @@ public class HighlightScanner {
             if (c.contains("x") && c.contains("y") && c.contains("z") && (c.contains("Items") || c.contains("id"))) {
                 results.add(c);
             }
-            for (String key : c.keySet()) {
+            for (String key : c.getAllKeys()) {
                 Tag el = c.get(key);
                 if (el instanceof CompoundTag child) extractNbts(child, results, visited, depth + 1);
                 else if (el instanceof ListTag list) {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "id": "litematica_container_filler",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "name": "Litematica Container Filler",
   "description": "Litematica mod for auto-filling containers",
   "authors": ["MimicEnzymes"],


### PR DESCRIPTION
- Add TTL-based cache eviction (5min) to RealContainerCache and LitematicaCache
- Add MAX_CACHE_ENTRIES=2048 limit with LRU eviction to RealContainerCache
- Add MAX_INDEPENDENT_CACHE_SIZE=1024 to ServuxSyncHandler
- Add ATTEMPT_COOLDOWNS retention cleanup (60s) to AreaScanner
- Fix BuiltBuffer resource leak in HighlightRenderer (try-finally)
- Change catch(Throwable) to catch(Exception) + Logger in HighlightRenderer
- Optimize SpatialKDTree: eliminate per-level ArrayList allocation
- Deduplicate AreaScanner scan logic into collectPendingTask()
- Fix MaterialReplacer split edge case: split arrow limit to 2
- Replace e.printStackTrace() with LOGGER in LitematicaContainerReader
- Return unmodifiableList from SpatialContainerIndex/LitematicaContainerIndex
- Use dedicated daemon executor for HighlightScanner async indexing
- Bump mod version 0.9.2 to 0.9.3