### PR TITLE
Fix memory leaks and improve cache management; bump 0.9.3 1.21.8

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.jvmargs=-Xmx2G
 maven_group=com.mimicenzymes
 archives_base_name=litematica_container_filler
 
-mod_version=0.9.2-1.21.8.7
+mod_version=0.9.3-1.21.8
 minecraft_version=1.21.8
 yarn_mappings=1.21.8+build.1
 loader_version=0.18.4

--- a/src/main/java/com/mimicenzymes/litematicafiller/core/AreaScanner.java
+++ b/src/main/java/com/mimicenzymes/litematicafiller/core/AreaScanner.java
@@ -18,6 +18,8 @@ import java.util.Map;
 import java.util.Set;
 
 public class AreaScanner {
+    private static final long ATTEMPT_COOLDOWN_MS = 5000L;
+    private static final long ATTEMPT_RETENTION_MS = 60000L;
     private static final Map<BlockPos, Long> ATTEMPT_COOLDOWNS = new HashMap<>();
 
     private static class PendingTask {
@@ -45,6 +47,7 @@ public class AreaScanner {
         int r = Configs.FILL_RADIUS.getIntegerValue();
         boolean syncLayer = Configs.SYNC_LITE_LAYER.getBooleanValue();
         long now = System.currentTimeMillis();
+        ATTEMPT_COOLDOWNS.entrySet().removeIf(entry -> now - entry.getValue() > ATTEMPT_RETENTION_MS);
 
         int maxTasks = isSilentPrinter ? 15 : 40;
 
@@ -57,28 +60,7 @@ public class AreaScanner {
 
         if (r == 0) {
             for (BlockPos rawPos : com.mimicenzymes.litematicafiller.render.HighlightScanner.getHighlights().keySet()) {
-                BlockState state = schematicWorld.getBlockState(rawPos);
-                if (state == null || state.isAir() || !state.hasBlockEntity()) continue;
-
-                BlockPos[] halves = LitematicaContainerReader.getDoubleContainerHalves(schematicWorld, rawPos, state);
-                BlockPos taskPos = halves != null ? halves[0] : rawPos;
-
-                if (!processedPositions.add(taskPos)) continue;
-
-                if (eyePos.squaredDistanceTo(Vec3d.ofCenter(taskPos)) > reachSq) continue;
-
-                if (isSilentPrinter && ATTEMPT_COOLDOWNS.containsKey(taskPos) && now - ATTEMPT_COOLDOWNS.get(taskPos) < 5000) {
-                    continue;
-                }
-
-                Map<Integer, ItemStack> required = LitematicaContainerReader.getRequiredItems(taskPos, mc.world.getRegistryManager());
-                boolean isCrafter = state.getBlock() instanceof net.minecraft.block.CrafterBlock;
-                boolean needsLocking = isCrafter && LitematicaContainerReader.doesCrafterNeedLocking(taskPos, mc);
-                boolean hasItems = required != null && !required.isEmpty() && !RealContainerCache.isSatisfied(taskPos, required);
-
-                if (!hasItems && !needsLocking) continue;
-
-                pendingTasks.add(new PendingTask(taskPos, required == null ? new HashMap<>() : required, taskPos.getSquaredDistance(center)));
+                collectPendingTask(mc, schematicWorld, center, eyePos, reachSq, now, isSilentPrinter, processedPositions, pendingTasks, rawPos);
             }
         } else {
             for (int x = -r; x <= r; x++) {
@@ -88,29 +70,7 @@ public class AreaScanner {
 
                         if (syncLayer && !fi.dy.masa.litematica.data.DataManager.getRenderLayerRange().isPositionWithinRange(rawPos)) continue;
 
-                        BlockState state = schematicWorld.getBlockState(rawPos);
-                        if (state.isAir() || !state.hasBlockEntity()) continue;
-
-                        BlockPos[] halves = LitematicaContainerReader.getDoubleContainerHalves(schematicWorld, rawPos, state);
-                        BlockPos taskPos = halves != null ? halves[0] : rawPos;
-
-                        if (!processedPositions.add(taskPos)) continue;
-
-                        if (eyePos.squaredDistanceTo(Vec3d.ofCenter(taskPos)) > reachSq) continue;
-
-                        if (isSilentPrinter && ATTEMPT_COOLDOWNS.containsKey(taskPos) && now - ATTEMPT_COOLDOWNS.get(taskPos) < 5000) {
-                            continue;
-                        }
-
-                        Map<Integer, ItemStack> required = LitematicaContainerReader.getRequiredItems(taskPos, mc.world.getRegistryManager());
-
-                        boolean isCrafter = state.getBlock() instanceof net.minecraft.block.CrafterBlock;
-                        boolean needsLocking = isCrafter && LitematicaContainerReader.doesCrafterNeedLocking(taskPos, mc);
-                        boolean hasItems = required != null && !required.isEmpty() && !RealContainerCache.isSatisfied(taskPos, required);
-
-                        if (!hasItems && !needsLocking) continue;
-
-                        pendingTasks.add(new PendingTask(taskPos, required == null ? new HashMap<>() : required, taskPos.getSquaredDistance(center)));
+                        collectPendingTask(mc, schematicWorld, center, eyePos, reachSq, now, isSilentPrinter, processedPositions, pendingTasks, rawPos);
                     }
                 }
             }
@@ -134,5 +94,39 @@ public class AreaScanner {
                 mc.player.sendMessage(Text.translatable("litematica_container_filler.message.no_requirements"), true);
             }
         }
+    }
+
+    private static void collectPendingTask(MinecraftClient mc,
+                                           net.minecraft.world.World schematicWorld,
+                                           BlockPos center,
+                                           Vec3d eyePos,
+                                           double reachSq,
+                                           long now,
+                                           boolean isSilentPrinter,
+                                           Set<BlockPos> processedPositions,
+                                           List<PendingTask> pendingTasks,
+                                           BlockPos rawPos) {
+        BlockState state = schematicWorld.getBlockState(rawPos);
+        if (state == null || state.isAir() || !state.hasBlockEntity()) return;
+
+        BlockPos[] halves = LitematicaContainerReader.getDoubleContainerHalves(schematicWorld, rawPos, state);
+        BlockPos taskPos = halves != null ? halves[0] : rawPos;
+
+        if (!processedPositions.add(taskPos)) return;
+        if (eyePos.squaredDistanceTo(Vec3d.ofCenter(taskPos)) > reachSq) return;
+
+        Long lastAttempt = ATTEMPT_COOLDOWNS.get(taskPos);
+        if (isSilentPrinter && lastAttempt != null && now - lastAttempt < ATTEMPT_COOLDOWN_MS) {
+            return;
+        }
+
+        Map<Integer, ItemStack> required = LitematicaContainerReader.getRequiredItems(taskPos, mc.world.getRegistryManager());
+        boolean isCrafter = state.getBlock() instanceof net.minecraft.block.CrafterBlock;
+        boolean needsLocking = isCrafter && LitematicaContainerReader.doesCrafterNeedLocking(taskPos, mc);
+        boolean hasItems = required != null && !required.isEmpty() && !RealContainerCache.isSatisfied(taskPos, required);
+
+        if (!hasItems && !needsLocking) return;
+
+        pendingTasks.add(new PendingTask(taskPos, required == null ? new HashMap<>() : required, taskPos.getSquaredDistance(center)));
     }
 }

--- a/src/main/java/com/mimicenzymes/litematicafiller/core/LitematicaCache.java
+++ b/src/main/java/com/mimicenzymes/litematicafiller/core/LitematicaCache.java
@@ -8,17 +8,45 @@ import java.util.Map;
 
 public class LitematicaCache
 {
+    private static final long CACHE_TTL_MS = 300000L;
     private static final Map<BlockPos, Map<Integer, ItemStack>> CACHE = new HashMap<>();
+    private static final Map<BlockPos, Long> CACHE_TIME = new HashMap<>();
+
     public static void clear()
     {
         CACHE.clear();
+        CACHE_TIME.clear();
     }
+
     public static void put(BlockPos pos, Map<Integer, ItemStack> items)
     {
-        CACHE.put(pos, items);
+        BlockPos key = pos.toImmutable();
+        CACHE.put(key, items);
+        CACHE_TIME.put(key, System.currentTimeMillis());
     }
+
     public static Map<Integer, ItemStack> get(BlockPos pos)
     {
+        Long seenAt = CACHE_TIME.get(pos);
+        if (seenAt == null)
+        {
+            return CACHE.get(pos);
+        }
+
+        if (System.currentTimeMillis() - seenAt > CACHE_TTL_MS)
+        {
+            CACHE.remove(pos);
+            CACHE_TIME.remove(pos);
+            return null;
+        }
+
         return CACHE.get(pos);
+    }
+
+    public static void cleanupExpired()
+    {
+        long now = System.currentTimeMillis();
+        CACHE_TIME.entrySet().removeIf(entry -> now - entry.getValue() > CACHE_TTL_MS);
+        CACHE.keySet().removeIf(pos -> !CACHE_TIME.containsKey(pos));
     }
 }

--- a/src/main/java/com/mimicenzymes/litematicafiller/core/LitematicaChangeListener.java
+++ b/src/main/java/com/mimicenzymes/litematicafiller/core/LitematicaChangeListener.java
@@ -9,6 +9,8 @@ public class LitematicaChangeListener {
     public static void tick(MinecraftClient mc) {
         Object current = SchematicWorldHandler.getSchematicWorld();
 
+        LitematicaCache.cleanupExpired();
+
         if (current != lastSchematic) {
             lastSchematic = current;
             LitematicaContainerIndex.rebuildIndex(mc);

--- a/src/main/java/com/mimicenzymes/litematicafiller/core/LitematicaContainerIndex.java
+++ b/src/main/java/com/mimicenzymes/litematicafiller/core/LitematicaContainerIndex.java
@@ -7,11 +7,14 @@ import fi.dy.masa.litematica.selection.Box;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Position;
+
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class LitematicaContainerIndex {
     private static final List<BlockPos> CONTAINERS = new ArrayList<>();
+    private static final List<BlockPos> VIEW = Collections.unmodifiableList(CONTAINERS);
 
     public static void rebuildIndex(MinecraftClient mc) {
         CONTAINERS.clear();
@@ -51,5 +54,5 @@ public class LitematicaContainerIndex {
         SpatialContainerIndex.rebuild(CONTAINERS);
     }
 
-    public static List<BlockPos> getContainers() { return CONTAINERS; }
+    public static List<BlockPos> getContainers() { return VIEW; }
 }

--- a/src/main/java/com/mimicenzymes/litematicafiller/core/LitematicaContainerReader.java
+++ b/src/main/java/com/mimicenzymes/litematicafiller/core/LitematicaContainerReader.java
@@ -1,5 +1,6 @@
 package com.mimicenzymes.litematicafiller.core;
 
+import com.mojang.logging.LogUtils;
 import fi.dy.masa.litematica.world.SchematicWorldHandler;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.ChestBlock;
@@ -11,6 +12,7 @@ import net.minecraft.nbt.NbtCompound;
 import net.minecraft.registry.RegistryWrapper;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
+import org.slf4j.Logger;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -18,6 +20,7 @@ import java.util.Map;
 import java.util.Set;
 
 public class LitematicaContainerReader {
+    private static final Logger LOGGER = LogUtils.getLogger();
 
     public static BlockPos[] getDoubleContainerHalves(net.minecraft.world.World world, BlockPos pos, BlockState state) {
         if (state.getBlock() instanceof ChestBlock) {
@@ -165,7 +168,7 @@ public class LitematicaContainerReader {
                     }
                 });
             } catch (Exception e) {
-                e.printStackTrace();
+                LOGGER.warn("Failed to read required item stack from schematic NBT", e);
             }
         }
 

--- a/src/main/java/com/mimicenzymes/litematicafiller/core/MaterialReplacer.java
+++ b/src/main/java/com/mimicenzymes/litematicafiller/core/MaterialReplacer.java
@@ -58,7 +58,7 @@ public class MaterialReplacer {
             REPLACEMENTS.clear();
             for (String rule : strings) {
                 if (rule == null || !rule.contains("->")) continue;
-                String[] parts = rule.split("->");
+                String[] parts = rule.split("->", 2);
                 if (parts.length != 2) continue;
 
                 ItemRule source = parseRule(parts[0].trim());

--- a/src/main/java/com/mimicenzymes/litematicafiller/core/RealContainerCache.java
+++ b/src/main/java/com/mimicenzymes/litematicafiller/core/RealContainerCache.java
@@ -24,10 +24,13 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class RealContainerCache {
+    private static final long CACHE_TTL_MS = 300000L;
+    private static final int MAX_CACHE_ENTRIES = 2048;
     private static final Map<BlockPos, Map<Integer, ItemStack>> CACHE = new ConcurrentHashMap<>();
     private static final Map<BlockPos, Set<Integer>> LOCK_CACHE = new ConcurrentHashMap<>();
     private static final Map<BlockPos, Map<Integer, ItemStack>> SYNC_SNAPSHOT_CACHE = new ConcurrentHashMap<>();
     private static final Map<BlockPos, Long> SYNC_SNAPSHOT_TIME = new ConcurrentHashMap<>();
+    private static final Map<BlockPos, Long> CACHE_TIME = new ConcurrentHashMap<>();
     private static BlockPos lastLookedPos = null;
     private static final long SYNC_SNAPSHOT_TTL_MS = 15000L;
 
@@ -47,6 +50,10 @@ public class RealContainerCache {
 
         if (client.world.getTime() % 100 == 0) {
             PENDING_NBT_REQUESTS.clear();
+        }
+
+        if (client.world.getTime() % 200 == 0) {
+            cleanupExpiredCache();
         }
 
         if (client.currentScreen == null && client.crosshairTarget instanceof BlockHitResult bhr) {
@@ -95,10 +102,10 @@ public class RealContainerCache {
         BlockPos[] halves = LitematicaContainerReader.getDoubleContainerHalves(client.world, pos, state);
 
         if (halves != null) {
-            CACHE.put(halves[0].toImmutable(), items);
-            CACHE.put(halves[1].toImmutable(), items);
+            putCachedItems(halves[0].toImmutable(), items);
+            putCachedItems(halves[1].toImmutable(), items);
         } else {
-            CACHE.put(pos.toImmutable(), items);
+            putCachedItems(pos.toImmutable(), items);
         }
 
         if (handler instanceof net.minecraft.screen.CrafterScreenHandler crafterHandler) {
@@ -235,6 +242,7 @@ public class RealContainerCache {
                     items = parseNbtInventory(nbt, client.world.getRegistryManager());
                 }
                 NBT_QUERY_CACHE.put(pos.toImmutable(), items);
+                CACHE_TIME.put(pos.toImmutable(), System.currentTimeMillis());
 
                 if (nbt.contains("disabled_slots")) {
                     LOCK_CACHE.put(pos.toImmutable(), parseDisabledSlots(nbt));
@@ -367,6 +375,7 @@ public class RealContainerCache {
         LOCK_CACHE.clear();
         SYNC_SNAPSHOT_CACHE.clear();
         SYNC_SNAPSHOT_TIME.clear();
+        CACHE_TIME.clear();
         NBT_QUERY_CACHE.clear();
         PENDING_NBT_REQUESTS.clear();
         LAST_REQUEST_TIME.clear();
@@ -376,7 +385,7 @@ public class RealContainerCache {
 
     public static void put(BlockPos pos, Map<Integer, ItemStack> items) {
         if (pos == null || items == null) return;
-        CACHE.put(pos.toImmutable(), items);
+        putCachedItems(pos.toImmutable(), items);
         cacheVersion++;
     }
 
@@ -396,6 +405,8 @@ public class RealContainerCache {
                 SYNC_SNAPSHOT_TIME.remove(halves[1]);
                 NBT_QUERY_CACHE.remove(halves[0]);
                 NBT_QUERY_CACHE.remove(halves[1]);
+                CACHE_TIME.remove(halves[0]);
+                CACHE_TIME.remove(halves[1]);
                 ServuxSyncHandler.INDEPENDENT_CACHE.remove(halves[0]);
                 ServuxSyncHandler.INDEPENDENT_CACHE.remove(halves[1]);
                 LAST_REQUEST_TIME.remove(halves[0]);
@@ -407,6 +418,7 @@ public class RealContainerCache {
         SYNC_SNAPSHOT_CACHE.remove(pos);
         SYNC_SNAPSHOT_TIME.remove(pos);
         NBT_QUERY_CACHE.remove(pos);
+        CACHE_TIME.remove(pos);
         ServuxSyncHandler.INDEPENDENT_CACHE.remove(pos);
         LAST_REQUEST_TIME.remove(pos);
         cacheVersion++;
@@ -520,6 +532,44 @@ public class RealContainerCache {
                     fi.dy.masa.litematica.config.Configs.Generic.ENTITY_DATA_SYNC_BACKUP.getBooleanValue();
         } catch (Throwable ignored) {
             return false;
+        }
+    }
+
+    private static void putCachedItems(BlockPos pos, Map<Integer, ItemStack> items) {
+        evictIfNeeded();
+        CACHE.put(pos, items);
+        CACHE_TIME.put(pos, System.currentTimeMillis());
+    }
+
+    private static void cleanupExpiredCache() {
+        long now = System.currentTimeMillis();
+        CACHE_TIME.entrySet().removeIf(entry -> now - entry.getValue() > CACHE_TTL_MS);
+        CACHE.keySet().removeIf(pos -> !CACHE_TIME.containsKey(pos));
+        LOCK_CACHE.keySet().removeIf(pos -> !CACHE_TIME.containsKey(pos));
+        NBT_QUERY_CACHE.keySet().removeIf(pos -> !CACHE_TIME.containsKey(pos));
+        LAST_REQUEST_TIME.keySet().removeIf(pos -> !CACHE_TIME.containsKey(pos));
+    }
+
+    private static void evictIfNeeded() {
+        if (CACHE.size() < MAX_CACHE_ENTRIES) {
+            return;
+        }
+
+        BlockPos oldest = null;
+        long oldestTime = Long.MAX_VALUE;
+        for (Map.Entry<BlockPos, Long> entry : CACHE_TIME.entrySet()) {
+            if (entry.getValue() < oldestTime) {
+                oldestTime = entry.getValue();
+                oldest = entry.getKey();
+            }
+        }
+
+        if (oldest != null) {
+            CACHE.remove(oldest);
+            LOCK_CACHE.remove(oldest);
+            NBT_QUERY_CACHE.remove(oldest);
+            LAST_REQUEST_TIME.remove(oldest);
+            CACHE_TIME.remove(oldest);
         }
     }
 }

--- a/src/main/java/com/mimicenzymes/litematicafiller/core/SpatialContainerIndex.java
+++ b/src/main/java/com/mimicenzymes/litematicafiller/core/SpatialContainerIndex.java
@@ -1,11 +1,14 @@
 package com.mimicenzymes.litematicafiller.core;
 
 import net.minecraft.util.math.BlockPos;
+
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class SpatialContainerIndex {
     private static final List<BlockPos> POSITIONS = new ArrayList<>();
+    private static final List<BlockPos> VIEW = Collections.unmodifiableList(POSITIONS);
 
     public static void rebuild(List<BlockPos> containers) {
         POSITIONS.clear();
@@ -26,5 +29,9 @@ public class SpatialContainerIndex {
             }
         }
         return result;
+    }
+
+    public static List<BlockPos> getPositions() {
+        return VIEW;
     }
 }

--- a/src/main/java/com/mimicenzymes/litematicafiller/core/SpatialKDTree.java
+++ b/src/main/java/com/mimicenzymes/litematicafiller/core/SpatialKDTree.java
@@ -25,31 +25,31 @@ public class SpatialKDTree
 
     public void build(List<BlockPos> points)
     {
-        root = buildRecursive(points, 0);
+        root = buildRecursive(new ArrayList<>(points), 0, 0, points.size());
     }
 
-    private Node buildRecursive(List<BlockPos> points, int depth)
+    private Node buildRecursive(List<BlockPos> points, int depth, int start, int end)
     {
-        if (points.isEmpty())
+        if (start >= end)
         {
             return null;
         }
 
         int axis = depth % 3;
 
-        points.sort((a, b) ->
+        points.subList(start, end).sort((a, b) ->
         {
             if (axis == 0) return Integer.compare(a.getX(), b.getX());
             if (axis == 1) return Integer.compare(a.getY(), b.getY());
             return Integer.compare(a.getZ(), b.getZ());
         });
 
-        int mid = points.size() / 2;
+        int mid = start + (end - start) / 2;
 
         Node node = new Node(points.get(mid), axis);
 
-        node.left = buildRecursive(new ArrayList<>(points.subList(0, mid)), depth + 1);
-        node.right = buildRecursive(points.subList(mid + 1, points.size()), depth + 1);
+        node.left = buildRecursive(points, depth + 1, start, mid);
+        node.right = buildRecursive(points, depth + 1, mid + 1, end);
 
         return node;
     }

--- a/src/main/java/com/mimicenzymes/litematicafiller/network/ServuxSyncHandler.java
+++ b/src/main/java/com/mimicenzymes/litematicafiller/network/ServuxSyncHandler.java
@@ -5,11 +5,14 @@ import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.BlockPos;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class ServuxSyncHandler {
+    private static final int MAX_INDEPENDENT_CACHE_SIZE = 1024;
 
     public static final Map<BlockPos, Map<Integer, ItemStack>> INDEPENDENT_CACHE = new ConcurrentHashMap<>();
 
@@ -27,7 +30,7 @@ public class ServuxSyncHandler {
             ClientPlayNetworking.registerGlobalReceiver(ServuxResponsePayload.ID, (payload, context) -> {
                 context.client().execute(() -> {
                     if (payload.pos() != null && payload.items() != null) {
-                        INDEPENDENT_CACHE.put(payload.pos().toImmutable(), payload.items());
+                        putIndependentCache(payload.pos().toImmutable(), payload.items());
                     }
                 });
             });
@@ -79,7 +82,7 @@ public class ServuxSyncHandler {
         }
 
         try {
-            for (java.lang.reflect.Field f : obj.getClass().getDeclaredFields()) {
+            for (Field f : obj.getClass().getDeclaredFields()) {
                 f.setAccessible(true);
                 Object val = f.get(obj);
 
@@ -108,7 +111,7 @@ public class ServuxSyncHandler {
 
         if (minihudCacheClass != null) {
             try {
-                for (java.lang.reflect.Field f : minihudCacheClass.getDeclaredFields()) {
+                for (Field f : minihudCacheClass.getDeclaredFields()) {
                     if (java.lang.reflect.Modifier.isStatic(f.getModifiers()) && Map.class.isAssignableFrom(f.getType())) {
                         f.setAccessible(true);
                         Map<?, ?> map = (Map<?, ?>) f.get(null);
@@ -123,13 +126,13 @@ public class ServuxSyncHandler {
                 }
 
                 Object cacheInstance = null;
-                for (java.lang.reflect.Method m : minihudCacheClass.getDeclaredMethods()) {
+                for (Method m : minihudCacheClass.getDeclaredMethods()) {
                     if (m.getName().equals("getInstance") && m.getParameterCount() == 0 && java.lang.reflect.Modifier.isStatic(m.getModifiers())) {
                         cacheInstance = m.invoke(null); break;
                     }
                 }
 
-                for (java.lang.reflect.Method m : minihudCacheClass.getDeclaredMethods()) {
+                for (Method m : minihudCacheClass.getDeclaredMethods()) {
                     if (m.getParameterCount() == 1 && m.getParameterTypes()[0] == BlockPos.class) {
                         m.setAccessible(true);
                         boolean isStatic = java.lang.reflect.Modifier.isStatic(m.getModifiers());
@@ -153,7 +156,7 @@ public class ServuxSyncHandler {
 
         if (minihudSenderClass != null) {
             try {
-                for (java.lang.reflect.Method m : minihudSenderClass.getDeclaredMethods()) {
+                for (Method m : minihudSenderClass.getDeclaredMethods()) {
                     if (m.getParameterCount() == 1 && m.getParameterTypes()[0] == BlockPos.class) {
                         String name = m.getName().toLowerCase();
                         if (name.contains("container") || name.contains("inventory") || name.contains("request") || name.contains("data") || name.contains("sync")) {
@@ -172,5 +175,16 @@ public class ServuxSyncHandler {
         }
 
         return false;
+    }
+
+    private static void putIndependentCache(BlockPos pos, Map<Integer, ItemStack> items) {
+        if (INDEPENDENT_CACHE.size() >= MAX_INDEPENDENT_CACHE_SIZE) {
+            var iterator = INDEPENDENT_CACHE.keySet().iterator();
+            if (iterator.hasNext()) {
+                iterator.next();
+                iterator.remove();
+            }
+        }
+        INDEPENDENT_CACHE.put(pos, items);
     }
 }

--- a/src/main/java/com/mimicenzymes/litematicafiller/render/HighlightRenderer.java
+++ b/src/main/java/com/mimicenzymes/litematicafiller/render/HighlightRenderer.java
@@ -1,18 +1,22 @@
 package com.mimicenzymes.litematicafiller.render;
 
+import com.mojang.logging.LogUtils;
 import com.mimicenzymes.litematicafiller.config.Configs;
 import fi.dy.masa.malilib.render.MaLiLibPipelines;
 import fi.dy.masa.malilib.render.RenderContext;
 import fi.dy.masa.malilib.render.RenderUtils;
 import fi.dy.masa.malilib.util.data.Color4f;
 import net.minecraft.client.MinecraftClient;
-import net.minecraft.util.math.BlockPos;
 import net.minecraft.client.render.BuiltBuffer;
+import net.minecraft.util.math.BlockPos;
+import org.slf4j.Logger;
 
 import java.util.Map;
 
 public class HighlightRenderer {
     private static final HighlightRenderer INSTANCE = new HighlightRenderer();
+    private static final Logger LOGGER = LogUtils.getLogger();
+
     public static HighlightRenderer getInstance() { return INSTANCE; }
 
     public void render() {
@@ -24,10 +28,13 @@ public class HighlightRenderer {
         MinecraftClient client = MinecraftClient.getInstance();
         if (client == null || client.world == null || client.player == null) return;
 
+        RenderContext ctx = null;
+        BuiltBuffer meshData = null;
+
         try {
             boolean xray = Configs.HIGHLIGHT_XRAY.getBooleanValue();
 
-            RenderContext ctx = new RenderContext(
+            ctx = new RenderContext(
                     () -> "litematica_filler_lines",
                     xray ? MaLiLibPipelines.DEBUG_LINES_MASA_SIMPLE_NO_DEPTH_NO_CULL : MaLiLibPipelines.DEBUG_LINES_MASA_SIMPLE_OFFSET_2
             );
@@ -41,13 +48,19 @@ public class HighlightRenderer {
                 Color4f c = getColor(entry.getValue());
                 RenderUtils.drawBlockBoundingBoxOutlinesBatchedLinesSimple(entry.getKey(), c, 0.015, buffer);
             }
-            BuiltBuffer meshData = buffer.endNullable();
+            meshData = buffer.endNullable();
             if (meshData != null) {
                 ctx.draw(meshData, false, true);
+            }
+        } catch (Exception e) {
+            LOGGER.warn("Failed to render container highlights", e);
+        } finally {
+            if (meshData != null) {
                 meshData.close();
             }
-            ctx.reset();
-        } catch (Throwable e) {
+            if (ctx != null) {
+                ctx.reset();
+            }
         }
     }
     private Color4f getColor(HighlightState type) {

--- a/src/main/java/com/mimicenzymes/litematicafiller/render/HighlightScanner.java
+++ b/src/main/java/com/mimicenzymes/litematicafiller/render/HighlightScanner.java
@@ -15,10 +15,17 @@ import net.minecraft.util.math.BlockPos;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 public class HighlightScanner {
     private static final Map<BlockPos, HighlightState> HIGHLIGHT_MAP = new ConcurrentHashMap<>();
     private static final Map<BlockPos, Map<Integer, ItemStack>> SCHEMATIC_REQ_CACHE = new ConcurrentHashMap<>();
+    private static final ExecutorService INDEX_EXECUTOR = Executors.newSingleThreadExecutor(r -> {
+        Thread thread = new Thread(r, "LitematicaFiller-HighlightScanner");
+        thread.setDaemon(true);
+        return thread;
+    });
     private static volatile Set<BlockPos> SCHEMATIC_CONTAINERS = Collections.emptySet();
     private static long lastIndexTime = 0;
     private static boolean isIndexing = false;
@@ -68,7 +75,7 @@ public class HighlightScanner {
             return;
         }
 
-        if (tickCounter % 100 == 0) SCHEMATIC_REQ_CACHE.clear();
+        if (tickCounter % 200 == 0) SCHEMATIC_REQ_CACHE.clear();
 
         long now = System.currentTimeMillis();
         if (!isIndexing && (now - lastIndexTime > 5000 || SCHEMATIC_CONTAINERS.isEmpty())) {
@@ -81,7 +88,7 @@ public class HighlightScanner {
                     lastIndexTime = System.currentTimeMillis();
                     isIndexing = false;
                 }
-            });
+            }, INDEX_EXECUTOR);
         }
 
         boolean hideCompleted = Configs.HIDE_COMPLETED_CONTAINERS.getBooleanValue();

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,7 +1,7 @@
 {
     "schemaVersion":  1,
     "id":  "litematica_container_filler",
-    "version": "0.9.2",
+    "version": "0.9.3",
     "name":  "Litematica Container Filler",
     "description":  "Litematica mod for auto-filling containers",
     "authors":  [
@@ -36,4 +36,3 @@
                      "modmenu":  "*"
                  }
 }
-


### PR DESCRIPTION
- Add TTL-based cache eviction (5min) to RealContainerCache and LitematicaCache
- Add MAX_CACHE_ENTRIES=2048 limit with LRU eviction to RealContainerCache
- Add MAX_INDEPENDENT_CACHE_SIZE=1024 to ServuxSyncHandler
- Add ATTEMPT_COOLDOWNS retention cleanup (60s) to AreaScanner
- Fix BuiltBuffer resource leak in HighlightRenderer (try-finally)
- Change catch(Throwable) to catch(Exception) + Logger in HighlightRenderer
- Optimize SpatialKDTree: eliminate per-level ArrayList allocation
- Deduplicate AreaScanner scan logic into collectPendingTask()
- Fix MaterialReplacer split edge case: split arrow limit to 2
- Replace e.printStackTrace() with Logger in LitematicaContainerReader
- Return unmodifiableList from SpatialContainerIndex/LitematicaContainerIndex
- Use dedicated daemon executor for HighlightScanner async indexing
- Bump mod version 0.9.2 to 0.9.3